### PR TITLE
Highlight tiles that were just played

### DIFF
--- a/pont-client/Cargo.toml
+++ b/pont-client/Cargo.toml
@@ -28,6 +28,7 @@ features = [
   'Element',
   'EventTarget',
   'FileReader',
+  'HtmlCollection',
   'HtmlElement',
   'HtmlButtonElement',
   'HtmlInputElement',

--- a/pont-client/deploy/style.css
+++ b/pont-client/deploy/style.css
@@ -18,6 +18,8 @@
     --green: #5e5;
     --red: #f55;
     --dark-red: #922;
+
+	--played: #228b22;
 }
 
 body {
@@ -159,6 +161,9 @@ g.placed rect.tile {
     fill: var(--dark3);
     stroke-width: 0.5;
     stroke: var(--dark4);
+}
+g.played rect.tile {
+    fill: var(--played);
 }
 div#svg_div.nyt g.piece rect.tile {
     fill: var(--dark3);

--- a/pont-client/src/lib.rs
+++ b/pont-client/src/lib.rs
@@ -874,6 +874,14 @@ impl Board {
         Ok(g)
     }
 
+    fn reset_played(&mut self) {
+        let prev_played = self.doc.get_elements_by_class_name("played");
+        for _i in 0..prev_played.length() {
+            let p = prev_played.item(0).unwrap();
+            p.class_list().remove_1("played");
+        }
+    } 
+
     fn on_reject_button(&mut self, evt: Event) -> JsError {
         // Don't allow for any tricky business here
         if self.state != BoardState::Idle {
@@ -964,6 +972,7 @@ impl Board {
     }
 
     fn on_move_accepted(&mut self, dealt: &[Piece]) -> JsError {
+        self.reset_played();
         let mut placed = HashMap::new();
         for ((x, y), i) in self.tentative.drain() {
             placed.insert(i, (x, y));
@@ -1590,6 +1599,7 @@ impl Playing {
     }
 
     fn on_played(&mut self, pieces: &[(Piece, i32, i32)]) -> JsError {
+        self.board.reset_played();
         let mut anims = Vec::new();
         let t0 = get_time_ms();
         for (piece, x, y) in pieces {

--- a/pont-client/src/lib.rs
+++ b/pont-client/src/lib.rs
@@ -867,6 +867,7 @@ impl Board {
         let g = self.new_piece(p)?;
         self.pan_group.append_child(&g)?;
         g.class_list().add_1("placed")?;
+        g.class_list().add_1("played")?;
         g.set_attribute("transform",
                         &format!("translate({} {})", x * 10, y * 10))?;
 


### PR DESCRIPTION
This is a very rudimentary solution to #4.

It adds a class *played* to the tiles on **add_piece** and then removes the *played* class from all tiles on **on_move_accepted** and **on_played**. 

The code is probably not good enough given my very limited knowledge of Rust, but it might be of some help.
