### PR TITLE
Fixed Excessive Rule: is_linear_connected -> is_linear

### DIFF
--- a/pont-common/src/lib.rs
+++ b/pont-common/src/lib.rs
@@ -177,13 +177,6 @@ impl Game {
         if xmin != xmax && ymin != ymax {
             return false;
         }
-        for x in xmin..=xmax {
-            for y in ymin..=ymax {
-                if !board.contains_key(&(x, y)) {
-                    return false;
-                }
-            }
-        }
         true
     }
 


### PR DESCRIPTION
The current is_linear_connected function is stricter than the actual game rules and prevents plays that are linear but disconnected. This deletion should remove the "connected" check but leave the "linear" check. This allows for plays that are linear but disconnected! Thanks.